### PR TITLE
Add Dockerfile and docker-compose.yml for Nginx setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+## © 2025 Little Shilling, Inc.
+## Shon Little
+## Created: 2025-05-11
+
+# Use an official Python runtime as a base image.
+FROM nginx:alpine
+# Copy the current directory contents into the container.
+COPY public /usr/share/nginx/html
+# Expose port 80 to the outside world.
+EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+# © 2025 Little Shilling, Inc.
+# Shon Little
+# Created: 2025-05-11
+
+# Networks.
+networks:
+  releve2024-network:
+    external: true
+
+# Nginx to serve static files.
+services:
+  shonlittle-nginx:
+    container_name: shonlittle-nginx
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: Dockerfile
+    expose:
+      - "80"
+    networks:
+      - releve2024-network


### PR DESCRIPTION
This pull request introduces Docker-based deployment for serving static files using Nginx. The changes include the creation of a `Dockerfile` and a `docker-compose.yml` file to define the container and its configuration.

### Docker setup for static file serving:

* **`Dockerfile`**: Added a Dockerfile that uses the `nginx:alpine` base image, copies static files from the `public` directory into the container, and exposes port 80 for external access.
* **`docker-compose.yml`**: Added a Docker Compose configuration file to define a service (`shonlittle-nginx`) that uses the `Dockerfile`, connects to an external network (`releve2024-network`), and exposes port 80.