### PR TITLE
Add Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+## © 2025 Little Shilling, Inc.
+## Shon Little
+## Created: 2025-05-11
+
+# Use an official Python runtime as a base image.
+FROM nginx:alpine
+# Copy the current directory contents into the container.
+COPY public /usr/share/nginx/html
+# Expose port 80 to the outside world.
+EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+# © 2025 Little Shilling, Inc.
+# Shon Little
+# Created: 2025-05-11
+
+# Networks.
+networks:
+  releve2024-network:
+    external: true
+
+# Nginx to serve static files.
+services:
+  shonlittle-nginx:
+    container_name: shonlittle-nginx
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: Dockerfile
+    expose:
+      - "80"
+    networks:
+      - releve2024-network


### PR DESCRIPTION
This pull request introduces a Docker setup for serving static files using Nginx. It includes the addition of a `Dockerfile` and a `docker-compose.yml` file to define the container and its configuration.

### Docker setup for serving static files:

* **`Dockerfile`**:
  - Added a base image (`nginx:alpine`) and configured it to copy static files from the `public` directory into the container's Nginx HTML directory (`/usr/share/nginx/html`).
  - Exposed port 80 for external access.

* **`docker-compose.yml`**:
  - Defined a custom network (`releve2024-network`) for the container.
  - Configured the `shonlittle-nginx` service to use the `Dockerfile`, restart unless stopped, and expose port 80.