### PR TITLE
Update docker-compose.yml: change Nginx port mapping from 80 to 3080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,6 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "80:80"
+      - "3080:80"
     networks:
       - releve2024-network


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change updates the port mapping for the service, changing the external port from `80` to `3080` while keeping the internal port as `80`.