### PR TITLE
Update port forwarding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,6 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "80:80"
+      - "3080:80"
     networks:
       - releve2024-network


### PR DESCRIPTION
This pull request includes a small update to the `docker-compose.yml` file. The change modifies the port mapping for the service, updating it from `80:80` to `3080:80` to avoid potential port conflicts.