### PR TITLE
Update Dockerfile: correct path for Nginx content copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN npm run build
 # Use an official Python runtime as a base image.
 FROM nginx:alpine
 # Copy the current directory contents into the container.
-COPY public /usr/share/nginx/html
+COPY --from=build /app/build /usr/share/nginx/html
 # Expose port 80 to the outside world.
 EXPOSE 80


### PR DESCRIPTION
This pull request updates the `Dockerfile` to improve the build process by using a multi-stage build. 

Key change:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L15-R15): Modified the `COPY` command to use the output from a build stage (`/app/build`) instead of directly copying the `public` directory. This ensures that only the built assets are included in the final image, reducing its size and improving efficiency.