### PR TITLE
Update Dockerfile: correct path for Nginx content copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN npm run build
 # Use an official Python runtime as a base image.
 FROM nginx:alpine
 # Copy the current directory contents into the container.
-COPY public /usr/share/nginx/html
+COPY --from=build /app/build /usr/share/nginx/html
 # Expose port 80 to the outside world.
 EXPOSE 80


### PR DESCRIPTION
This pull request updates the `Dockerfile` to improve the container build process by using a multi-stage build approach. The most important change is the modification of the `COPY` command to copy files from a build stage instead of directly from the local `public` directory.

Improvements to container build process:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L15-R15): Updated the `COPY` command to use `--from=build /app/build` as the source, enabling a multi-stage build process for better separation of concerns and reduced image size.