### PR TITLE
Add nginx configuration file for server setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN npm run build
 
 # Use an official Python runtime as a base image.
 FROM nginx:alpine
+# Copy the default nginx configuration file
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 # Copy the current directory contents into the container.
 COPY --from=build /app/build /usr/share/nginx/html
 # Expose port 80 to the outside world.

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,15 @@
+# © 2025 Little Shilling, Inc.
+# Shon Little
+# Created: 2025-05-12
+
+server {
+  listen 80;
+  server_name shonlittle.com;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+}


### PR DESCRIPTION
This pull request introduces changes to set up a custom Nginx configuration for serving a static website. The key updates include copying a custom Nginx configuration file into the Docker image and defining the server configuration to handle requests.

### Dockerfile updates:
* Added a step to copy the custom Nginx configuration file (`nginx/default.conf`) into the container at `/etc/nginx/conf.d/default.conf`.

### Nginx configuration:
* Added a new `nginx/default.conf` file to configure the Nginx server. This file sets up the server to listen on port 80, use `/usr/share/nginx/html` as the root directory, serve `index.html` as the default file, and handle requests with `try_files` to support single-page applications.