### PR TITLE
Set up a custom Nginx configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN npm run build
 
 # Use an official Python runtime as a base image.
 FROM nginx:alpine
+# Copy the default nginx configuration file
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 # Copy the current directory contents into the container.
 COPY --from=build /app/build /usr/share/nginx/html
 # Expose port 80 to the outside world.

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,15 @@
+# © 2025 Little Shilling, Inc.
+# Shon Little
+# Created: 2025-05-12
+
+server {
+  listen 80;
+  server_name shonlittle.com;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+}


### PR DESCRIPTION
This pull request introduces changes to set up a custom Nginx configuration for serving a static website. The key updates include copying a custom Nginx configuration file into the container and defining the server configuration in the `default.conf` file.

### Nginx configuration setup:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R20-R21): Added a step to copy the custom Nginx configuration file (`nginx/default.conf`) into the container's Nginx configuration directory (`/etc/nginx/conf.d/`).
* [`nginx/default.conf`](diffhunk://#diff-2a889766ffd2dddaae142742fb6db4a74fcf8cd3e65401a326e1db3b045263daR1-R15): Created a custom Nginx configuration file to define the server behavior. The configuration includes listening on port 80, setting the server name to `shonlittle.com`, specifying the document root, and enabling fallback to `index.html` for single-page applications.